### PR TITLE
Install needs pysql-dll

### DIFF
--- a/unix/requirements.txt
+++ b/unix/requirements.txt
@@ -4,4 +4,4 @@
 #
 PySDL2
 Pillow
-
+pysdl2-dll


### PR DESCRIPTION
Fixes error `ImportError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)` when trying to run simulator on new/fresh ubu20.04 install